### PR TITLE
feat: support keys with zero or N subkeys and multiple uids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,34 +1,26 @@
 # Ignore everything and selectively allow files
 *
 
-# Allow project files
-!.deepsource.toml
-!.dockerignore
+!/.envrc
 !.github/**/*
-!.gitignore
+!/.gitignore
 !.zed/settings.json
-!CODEOWNERS
-!CODE_OF_CONDUCT.md
-!Dockerfile*
-!LICENSE
-!README.md
+!/build.rs
+!/Cargo.lock
+!/Cargo.toml
+!/CODEOWNERS
+!/CODE_OF_CONDUCT.md
+!/default.nix
+!/flake.lock
+!/flake.nix
+!/LICENSE
+!/README.md
 !scripts/*
-!typos.toml
-
-# Allow Nix files
-!.envrc
-!flake.nix
-!flake.lock
-!default.nix
-
-# Allow Rust files
-!Cargo.toml
-!Cargo.lock
 !src/*.rs
 !src/snapshots/*
-!tests/*.rs
+!tests/**/*.rs
 !tests/testdata/*
-!build.rs
+!/typos.toml
 target/**/*
 
 # Recurse through sub-directories applying the same patterns

--- a/src/gpg.rs
+++ b/src/gpg.rs
@@ -6,8 +6,7 @@ use nom::{
     bytes::complete::{tag, take_until},
     character::complete::not_line_ending,
     error::Error,
-    multi::count,
-    sequence::{pair, separated_pair},
+    sequence::separated_pair,
     AsChar, Finish, IResult, Parser,
 };
 use std::{
@@ -140,14 +139,31 @@ fn reload_agent() -> Result<()> {
 /// A GPG private key
 #[derive(Debug)]
 pub struct GpgPrivateKey {
-    /// The user name associated with the private key
-    pub user_name: String,
-    /// The user email associated with the private key
-    pub user_email: String,
+    /// The user identities associated with the private key; the first is
+    /// used as the default git identity
+    pub uids: Vec<GpgUid>,
     /// Internal details of the secret key
     pub secret_key: GpgKeyDetails,
-    /// Internal details of the secret subkey
-    pub secret_subkey: GpgKeyDetails,
+    /// Internal details of the secret subkeys (0..N)
+    pub subkeys: Vec<GpgKeyDetails>,
+}
+
+impl GpgPrivateKey {
+    /// The primary user identity, used as the default git identity
+    pub fn primary_uid(&self) -> &GpgUid {
+        self.uids.first().expect(
+            "GpgPrivateKey invariant violated: uids must be non-empty (only construct via parsing)",
+        )
+    }
+}
+
+/// A user identity associated with a GPG key
+#[derive(Debug, PartialEq, Eq)]
+pub struct GpgUid {
+    /// The name portion of the user id
+    pub name: String,
+    /// The email portion of the user id
+    pub email: String,
 }
 
 /// Contains internal details of a GPG private key
@@ -163,29 +179,54 @@ pub struct GpgKeyDetails {
     pub key_id: String,
     /// A 20-byte hash identifier for the private key
     pub keygrip: String,
+    /// The operations this key or subkey is capable of
+    pub capabilities: GpgCapabilities,
+}
+
+/// The set of operations a GPG key or subkey is capable of, derived from the
+/// lowercase letters in the colon-format capabilities field. Uppercase
+/// letters in that field summarise the primary key's aggregate capability
+/// across all subkeys and are ignored here in favour of this key's own.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct GpgCapabilities {
+    /// The key can be used to create signatures
+    pub sign: bool,
+    /// The key can be used to encrypt data
+    pub encrypt: bool,
+    /// The key can be used to certify other keys
+    pub certify: bool,
+    /// The key can be used for authentication
+    pub authenticate: bool,
+}
+
+impl From<&str> for GpgCapabilities {
+    fn from(field: &str) -> Self {
+        GpgCapabilities {
+            sign: field.contains('s'),
+            encrypt: field.contains('e'),
+            certify: field.contains('c'),
+            authenticate: field.contains('a'),
+        }
+    }
 }
 
 impl FromStr for GpgPrivateKey {
-    type Err = Error<String>;
+    type Err = GpgError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match parse_gpg_key_details(s).finish() {
-            Ok((_, info)) => Ok(info),
-            Err(Error { input, code }) => Err(Error {
-                input: input.to_string(),
-                code,
-            }),
-        }
+        parse_gpg_key_details(s)
     }
 }
 
 impl Display for GpgPrivateKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(
-            f,
-            "user:           {} <{}>",
-            self.user_name, self.user_email
-        )?;
+        for uid in &self.uids {
+            if uid.email.is_empty() {
+                writeln!(f, "user:           {}", uid.name)?;
+            } else {
+                writeln!(f, "user:           {} <{}>", uid.name, uid.email)?;
+            }
+        }
         writeln!(f, "fingerprint:    {}", self.secret_key.fingerprint)?;
         writeln!(f, "keygrip:        {}", self.secret_key.keygrip)?;
         writeln!(f, "key_id:         {}", self.secret_key.key_id)?;
@@ -195,26 +236,29 @@ impl Display for GpgPrivateKey {
             format_timestamp(self.secret_key.creation_date)
         )?;
 
-        if self.secret_key.expiration_date.is_some() {
+        if let Some(expiration_date) = self.secret_key.expiration_date {
             writeln!(
                 f,
                 "expires_on:     {}",
-                format_expiration_in_days(self.secret_key.expiration_date.unwrap())
+                format_expiration_in_days(expiration_date)
             )?;
         }
-        writeln!(f, "sub_keygrip:    {}", self.secret_subkey.keygrip)?;
-        writeln!(f, "sub_key_id:     {}", self.secret_subkey.key_id)?;
-        writeln!(
-            f,
-            "sub_created_on: {}",
-            format_timestamp(self.secret_subkey.creation_date)
-        )?;
-        if self.secret_subkey.expiration_date.is_some() {
+
+        for subkey in &self.subkeys {
+            writeln!(f, "sub_keygrip:    {}", subkey.keygrip)?;
+            writeln!(f, "sub_key_id:     {}", subkey.key_id)?;
             writeln!(
                 f,
-                "sub_expires_on: {}",
-                format_expiration_in_days(self.secret_subkey.expiration_date.unwrap())
+                "sub_created_on: {}",
+                format_timestamp(subkey.creation_date)
             )?;
+            if let Some(expiration_date) = subkey.expiration_date {
+                writeln!(
+                    f,
+                    "sub_expires_on: {}",
+                    format_expiration_in_days(expiration_date)
+                )?;
+            }
         }
         Ok(())
     }
@@ -255,57 +299,205 @@ fn parse_status_import(status: &str) -> Option<String> {
         .map(String::from)
 }
 
-fn parse_gpg_key_details(input: &str) -> IResult<&str, GpgPrivateKey> {
-    let (i, _) = (tag("sec"), count(pair(take_until(":"), tag(":")), 4)).parse(input)?;
-    let (i, sec) = count(pair(take_until(":"), tag(":")), 3).parse(i)?;
-    let (i, _) = (take_until("fpr"), tag("fpr"), count(tag(":"), 9)).parse(i)?;
-    let (i, sec_fpr) = take_until(":")(i)?;
-    let (i, _) = (take_until("grp"), tag("grp"), count(tag(":"), 9)).parse(i)?;
-    let (i, sec_grp) = take_until(":")(i)?;
-    let (i, _) = (
-        take_until("uid"),
-        tag("uid"),
-        count(pair(take_until(":"), tag(":")), 9),
-    )
-        .parse(i)?;
-    let (i, uid) = separated_pair(take_until(" <"), tag(" <"), take_until(">")).parse(i)?;
-    let (i, _) = take_until("ssb")(i)?;
-    let (i, _) = (tag("ssb"), count(pair(take_until(":"), tag(":")), 4)).parse(i)?;
-    let (i, ssb) = count(pair(take_until(":"), tag(":")), 3).parse(i)?;
-    let (i, _) = (take_until("fpr"), tag("fpr"), count(tag(":"), 9)).parse(i)?;
-    let (i, ssb_fpr) = take_until(":")(i)?;
-    let (i, _) = (take_until("grp"), tag("grp"), count(tag(":"), 9)).parse(i)?;
-    let (i, ssb_grp) = take_until(":")(i)?;
+/// Field indices (0-based, after splitting a colon-format line on `:`),
+/// verified against real `gpg --with-colons --with-keygrip` output.
+mod colon_field {
+    pub const KEY_ID: usize = 4;
+    pub const CREATION_DATE: usize = 5;
+    pub const EXPIRATION_DATE: usize = 6;
+    pub const CAPABILITIES: usize = 11;
+    /// Shared by `fpr` (fingerprint), `grp` (keygrip) and `uid` (user id text)
+    pub const RECORD_VALUE: usize = 9;
+}
 
-    Ok((
-        i,
-        GpgPrivateKey {
-            user_name: uid.0.into(),
-            user_email: uid.1.into(),
-            secret_key: GpgKeyDetails {
-                creation_date: sec[1].0.parse::<i64>().unwrap(),
-                expiration_date: if sec[2].0.is_empty() {
-                    None
+/// Parses gpg `--with-colons --with-keygrip` output for a single private key
+/// into a [`GpgPrivateKey`]. Each line is dispatched independently on its
+/// leading record tag, so a `uid` value containing text that happens to
+/// match another tag (e.g. `ssb`) cannot derail parsing.
+fn parse_gpg_key_details(input: &str) -> Result<GpgPrivateKey, GpgError> {
+    let mut secret_key: Option<GpgKeyDetails> = None;
+    let mut subkeys: Vec<GpgKeyDetails> = Vec::new();
+    let mut uids: Vec<GpgUid> = Vec::new();
+
+    for (line_no, line) in input.lines().enumerate() {
+        let fields: Vec<&str> = line.split(':').collect();
+
+        match fields.first().copied().unwrap_or_default() {
+            "sec" | "ssb" => {
+                let details = GpgKeyDetails {
+                    key_id: field(&fields, colon_field::KEY_ID, line_no, line)?.to_string(),
+                    creation_date: parse_timestamp(
+                        field(&fields, colon_field::CREATION_DATE, line_no, line)?,
+                        line_no,
+                        line,
+                    )?,
+                    expiration_date: parse_optional_timestamp(
+                        field(&fields, colon_field::EXPIRATION_DATE, line_no, line)?,
+                        line_no,
+                        line,
+                    )?,
+                    fingerprint: String::new(),
+                    keygrip: String::new(),
+                    capabilities: field(&fields, colon_field::CAPABILITIES, line_no, line)?.into(),
+                };
+
+                if fields[0] == "sec" {
+                    if secret_key.is_some() {
+                        return Err(GpgError::InvalidGpgKeyData(
+                            "multiple primary keys (sec records) found in input; expected exactly one"
+                                .to_string(),
+                        ));
+                    }
+                    secret_key = Some(details);
                 } else {
-                    Some(sec[2].0.parse::<i64>().unwrap())
-                },
-                fingerprint: sec_fpr.into(),
-                key_id: sec[0].0.into(),
-                keygrip: sec_grp.into(),
-            },
-            secret_subkey: GpgKeyDetails {
-                creation_date: ssb[1].0.parse::<i64>().unwrap(),
-                expiration_date: if ssb[2].0.is_empty() {
-                    None
-                } else {
-                    Some(ssb[2].0.parse::<i64>().unwrap())
-                },
-                fingerprint: ssb_fpr.into(),
-                key_id: ssb[0].0.into(),
-                keygrip: ssb_grp.into(),
-            },
-        },
-    ))
+                    subkeys.push(details);
+                }
+            }
+            "fpr" => {
+                current_key(&mut secret_key, &mut subkeys, line_no, line)?.fingerprint =
+                    field(&fields, colon_field::RECORD_VALUE, line_no, line)?.to_string();
+            }
+            "grp" => {
+                current_key(&mut secret_key, &mut subkeys, line_no, line)?.keygrip =
+                    field(&fields, colon_field::RECORD_VALUE, line_no, line)?.to_string();
+            }
+            "uid" => {
+                uids.push(parse_uid(
+                    field(&fields, colon_field::RECORD_VALUE, line_no, line)?,
+                    line_no,
+                    line,
+                )?);
+            }
+            _ => {}
+        }
+    }
+
+    let secret_key =
+        secret_key.ok_or_else(|| GpgError::InvalidGpgKeyData("missing sec record".to_string()))?;
+    if uids.is_empty() {
+        return Err(GpgError::InvalidGpgKeyData(
+            "missing uid record".to_string(),
+        ));
+    }
+
+    validate_key_details(&secret_key, "primary key")?;
+    for (i, subkey) in subkeys.iter().enumerate() {
+        validate_key_details(subkey, &format!("subkey {}", i + 1))?;
+    }
+
+    Ok(GpgPrivateKey {
+        uids,
+        secret_key,
+        subkeys,
+    })
+}
+
+/// Ensures a `sec`/`ssb` record was followed by its `fpr` and `grp` records;
+/// without them the fingerprint/keygrip are silently empty, which surfaces
+/// as a confusing failure much later (e.g. presetting the passphrase for an
+/// empty keygrip) rather than here, at parse time.
+fn validate_key_details(details: &GpgKeyDetails, label: &str) -> Result<(), GpgError> {
+    if details.fingerprint.is_empty() || details.keygrip.is_empty() {
+        return Err(GpgError::InvalidGpgKeyData(format!(
+            "{label} is missing its fingerprint or keygrip (no matching fpr/grp record)"
+        )));
+    }
+    Ok(())
+}
+
+/// Returns the key details that a following `fpr`/`grp` record applies to:
+/// the most recently opened subkey, falling back to the primary key.
+fn current_key<'a>(
+    secret_key: &'a mut Option<GpgKeyDetails>,
+    subkeys: &'a mut [GpgKeyDetails],
+    line_no: usize,
+    line: &str,
+) -> Result<&'a mut GpgKeyDetails, GpgError> {
+    subkeys
+        .last_mut()
+        .or(secret_key.as_mut())
+        .ok_or_else(|| GpgError::MalformedKeyRecord(line_no + 1, line.to_string()))
+}
+
+fn field<'a>(
+    fields: &[&'a str],
+    idx: usize,
+    line_no: usize,
+    line: &str,
+) -> Result<&'a str, GpgError> {
+    fields
+        .get(idx)
+        .copied()
+        .ok_or_else(|| GpgError::MalformedKeyRecord(line_no + 1, line.to_string()))
+}
+
+fn parse_timestamp(value: &str, line_no: usize, line: &str) -> Result<i64, GpgError> {
+    value
+        .parse::<i64>()
+        .map_err(|_| GpgError::MalformedKeyRecord(line_no + 1, line.to_string()))
+}
+
+fn parse_optional_timestamp(
+    value: &str,
+    line_no: usize,
+    line: &str,
+) -> Result<Option<i64>, GpgError> {
+    if value.is_empty() {
+        Ok(None)
+    } else {
+        parse_timestamp(value, line_no, line).map(Some)
+    }
+}
+
+/// Decodes GnuPG's `--with-colons` escaping for free-form text fields
+/// (currently only the uid field). Bytes that would be ambiguous in the
+/// colon-delimited format -- notably `:` and `\` -- are written as
+/// `\xHH`; verified against real gpg output (`Batman: Dark Knight` is
+/// emitted as `Batman\x3a Dark Knight`, a literal `\` as `\x5c`).
+/// Everything else, including multi-byte UTF-8, passes through as-is.
+fn unescape_colon_field(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] == b'\\' && i + 3 < bytes.len() && bytes[i + 1] == b'x' {
+            let hi = (bytes[i + 2] as char).to_digit(16);
+            let lo = (bytes[i + 3] as char).to_digit(16);
+            if let (Some(hi), Some(lo)) = (hi, lo) {
+                out.push((hi * 16 + lo) as u8);
+                i += 4;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Parses a uid field, expected to look like `Name <email>`. GnuPG doesn't
+/// guarantee an email is present (e.g. name-only user ids), so a missing
+/// ` <...>` segment is treated as a name-only uid rather than an error; an
+/// unterminated one (` <` with no closing `>`) is still malformed.
+fn parse_uid(value: &str, line_no: usize, line: &str) -> Result<GpgUid, GpgError> {
+    let value = unescape_colon_field(value);
+    let Some((name, rest)) = value.split_once(" <") else {
+        return Ok(GpgUid {
+            name: value.to_string(),
+            email: String::new(),
+        });
+    };
+
+    let email = rest
+        .strip_suffix('>')
+        .ok_or_else(|| GpgError::MalformedKeyRecord(line_no + 1, line.to_string()))?;
+
+    Ok(GpgUid {
+        name: name.to_string(),
+        email: email.to_string(),
+    })
 }
 
 /// Errors that can occur when working with GPG keys
@@ -322,6 +514,10 @@ pub enum GpgError {
     /// The decoded data is not a valid GPG key
     #[error("decoded data is not a valid gpg key: {0}")]
     InvalidGpgKeyData(String),
+
+    /// A colon-format record from gpg could not be parsed
+    #[error("malformed gpg colon record on line {0}: {1}")]
+    MalformedKeyRecord(usize, String),
 
     /// The specified key was not found in the keyring
     #[error("gpg key not found: {0}")]
@@ -380,9 +576,7 @@ pub fn preview_key(key: &str) -> Result<GpgPrivateKey> {
     }
 
     let output = String::from_utf8(gpg_preview.stdout)?;
-    let key_details = output
-        .parse::<GpgPrivateKey>()
-        .map_err(|_| GpgError::InvalidGpgKeyData(output.trim().to_string()))?;
+    let key_details = output.parse::<GpgPrivateKey>()?;
 
     Ok(key_details)
 }
@@ -464,15 +658,12 @@ pub fn extract_key_info(key_id: &str) -> Result<GpgPrivateKey> {
         }
     }
 
-    if let Some(expiration_date) = key_details.secret_subkey.expiration_date {
-        if expiration_date <= current_timestamp {
-            bail!(
-                "GPG secret subkey has expired on {}",
-                Utc.timestamp_opt(expiration_date, 0).unwrap().to_rfc2822()
-            );
-        }
-    }
-
+    // Subkey expiry is intentionally not checked here: which subkey (if any)
+    // is actually used for signing isn't known until the caller resolves a
+    // signing key (e.g. via --fingerprint), so an expired, non-selected
+    // subkey must not block an otherwise-usable key. See
+    // GpgImport::configure_git_signing, which validates expiry for the
+    // specific key that was selected.
     Ok(key_details)
 }
 
@@ -649,22 +840,57 @@ Pubkey: RSA, ELG, DSA, ECDH, ECDSA, EDDSA";
     #[test]
     fn display_gpg_private_key_without_expiration() {
         let key = GpgPrivateKey {
-            user_name: "batman".to_string(),
-            user_email: "batman@dc.com".to_string(),
+            uids: vec![GpgUid {
+                name: "batman".to_string(),
+                email: "batman@dc.com".to_string(),
+            }],
             secret_key: GpgKeyDetails {
                 creation_date: 1700000000,
                 expiration_date: None,
                 fingerprint: "BEEA4CDB4B0A80CBABB99B45FDEFE8AB8796E127".to_string(),
                 key_id: "FDEFE8AB8796E127".to_string(),
                 keygrip: "C4403DA4AF911084480BA46743E707CCDD082A24".to_string(),
+                capabilities: GpgCapabilities {
+                    sign: true,
+                    certify: true,
+                    ..Default::default()
+                },
             },
-            secret_subkey: GpgKeyDetails {
+            subkeys: vec![GpgKeyDetails {
                 creation_date: 1700000000,
                 expiration_date: None,
                 fingerprint: "F36BE03211AF1D3CE26D8B3ABE6663F6A323FBE8".to_string(),
                 key_id: "BE6663F6A323FBE8".to_string(),
                 keygrip: "4AC8E7E7FD8B405DF2761726D296F98C9B778875".to_string(),
+                capabilities: GpgCapabilities {
+                    encrypt: true,
+                    ..Default::default()
+                },
+            }],
+        };
+        insta::assert_snapshot!(key.to_string());
+    }
+
+    #[test]
+    fn display_gpg_private_key_with_name_only_uid() {
+        let key = GpgPrivateKey {
+            uids: vec![GpgUid {
+                name: "batman".to_string(),
+                email: String::new(),
+            }],
+            secret_key: GpgKeyDetails {
+                creation_date: 1700000000,
+                expiration_date: None,
+                fingerprint: "BEEA4CDB4B0A80CBABB99B45FDEFE8AB8796E127".to_string(),
+                key_id: "FDEFE8AB8796E127".to_string(),
+                keygrip: "C4403DA4AF911084480BA46743E707CCDD082A24".to_string(),
+                capabilities: GpgCapabilities {
+                    sign: true,
+                    certify: true,
+                    ..Default::default()
+                },
             },
+            subkeys: vec![],
         };
         insta::assert_snapshot!(key.to_string());
     }
@@ -708,8 +934,9 @@ grp:::::::::4AC8E7E7FD8B405DF2761726D296F98C9B778875:",
         assert!(result.is_ok(), "Should parse GPG colon format");
 
         let key = result.unwrap();
-        assert_eq!(key.user_name, "batman");
-        assert_eq!(key.user_email, "batman@dc.com");
+        assert_eq!(key.uids.len(), 1);
+        assert_eq!(key.primary_uid().name, "batman");
+        assert_eq!(key.primary_uid().email, "batman@dc.com");
         assert_eq!(key.secret_key.creation_date, now.timestamp());
         assert_eq!(
             key.secret_key.expiration_date,
@@ -724,15 +951,259 @@ grp:::::::::4AC8E7E7FD8B405DF2761726D296F98C9B778875:",
             key.secret_key.keygrip,
             "C4403DA4AF911084480BA46743E707CCDD082A24"
         );
-        assert_eq!(key.secret_subkey.creation_date, now.timestamp());
+        assert!(key.secret_key.capabilities.sign);
+        assert!(key.secret_key.capabilities.certify);
+        assert!(!key.secret_key.capabilities.encrypt);
+
+        assert_eq!(key.subkeys.len(), 1);
+        let subkey = &key.subkeys[0];
+        assert_eq!(subkey.creation_date, now.timestamp());
         assert_eq!(
-            key.secret_subkey.expiration_date,
+            subkey.expiration_date,
             Some(secret_subkey_expiration.timestamp())
         );
-        assert_eq!(key.secret_subkey.key_id, "BE6663F6A323FBE8");
+        assert_eq!(subkey.key_id, "BE6663F6A323FBE8");
+        assert_eq!(subkey.keygrip, "4AC8E7E7FD8B405DF2761726D296F98C9B778875");
+        assert!(subkey.capabilities.encrypt);
+        assert!(!subkey.capabilities.sign);
+    }
+
+    #[test]
+    fn parse_sign_only_key_without_subkey() {
+        let gpg_colon_format = "sec:u:4096:1:CA953C1735BEEB77:1700000000:::u:::scSC:::+:::23::0:
+fpr:::::::::53C53C910B205E504F69EEA3CA953C1735BEEB77:
+grp:::::::::591F029DF76C1A0673B7122D97CF0FA3962561DD:
+uid:u::::1700000000::96652C75728C60697573C3570C362BED95E6544::robin <robin@dc.com>::::::::::0:";
+
+        let result = gpg_colon_format.parse::<GpgPrivateKey>();
+        assert!(result.is_ok(), "Should parse a sign-only key");
+
+        let key = result.unwrap();
+        assert!(key.subkeys.is_empty());
+        assert_eq!(key.primary_uid().name, "robin");
+    }
+
+    #[test]
+    fn parse_multiple_subkeys_with_capabilities() {
+        let gpg_colon_format = "sec:u:2048:1:B8527C5AED483BE3:1700000000:::u:::scESCA:::+:::23::0:
+fpr:::::::::24DA69B1615F5F3C6A9C3A60B8527C5AED483BE3:
+grp:::::::::4D74903B8F3C8B017B3DC9FAA602D29429748FEE:
+uid:u::::1700000000::0E9C7598797E7F7A380A72A58B9B7FA28160AB06::batman <batman@dc.com>::::::::::0:
+ssb:u:2048:1:B5F51E0E91062E1F:1700000000::::::e:::+:::23:
+fpr:::::::::1151789CA9BEAFCB8998FB0CB5F51E0E91062E1F:
+grp:::::::::7C1FAF12BFE4399DF3C64D6C16354057232DD75A:
+ssb:u:2048:1:28BA2DEA0CFC5717:1700000100::::::s:::+:::23:
+fpr:::::::::15404EFABA5A81EDBFA6C6B628BA2DEA0CFC5717:
+grp:::::::::B644058C06C9EDA6E0EFBAAD8C847A86739DE73F:
+ssb:u:2048:1:34E7EF9A6D5E41E6:1700000200::::::a:::+:::23:
+fpr:::::::::AA5C366A86714B60DAD2DEA634E7EF9A6D5E41E6:
+grp:::::::::6CD0471E9E43B60B911B7DA083B836ED51494DB7:";
+
+        let result = gpg_colon_format.parse::<GpgPrivateKey>();
+        assert!(result.is_ok(), "Should parse a key with 3 subkeys");
+
+        let key = result.unwrap();
+        assert_eq!(key.subkeys.len(), 3);
+
+        assert_eq!(key.subkeys[0].key_id, "B5F51E0E91062E1F");
+        assert!(key.subkeys[0].capabilities.encrypt);
+        assert!(!key.subkeys[0].capabilities.sign);
+
+        assert_eq!(key.subkeys[1].key_id, "28BA2DEA0CFC5717");
+        assert!(key.subkeys[1].capabilities.sign);
+        assert!(!key.subkeys[1].capabilities.encrypt);
+
+        assert_eq!(key.subkeys[2].key_id, "34E7EF9A6D5E41E6");
+        assert!(key.subkeys[2].capabilities.authenticate);
+    }
+
+    #[test]
+    fn parse_multiple_uids() {
+        let gpg_colon_format = "sec:u:4096:1:FDEFE8AB8796E127:1700000000:::u:::scESC:::+:::23::0:
+fpr:::::::::BEEA4CDB4B0A80CBABB99B45FDEFE8AB8796E127:
+grp:::::::::C4403DA4AF911084480BA46743E707CCDD082A24:
+uid:u::::1700000000::0E9C7598797E7F7A380A72A58B9B7FA28160AB06::batman <batman@dc.com>::::::::::0:
+uid:u::::1700000000::1E9C7598797E7F7A380A72A58B9B7FA28160AB07::bruce wayne <bruce@wayne.com>::::::::::0:";
+
+        let result = gpg_colon_format.parse::<GpgPrivateKey>();
+        assert!(result.is_ok(), "Should parse a key with multiple uids");
+
+        let key = result.unwrap();
+        assert_eq!(key.uids.len(), 2);
+        assert_eq!(key.primary_uid().name, "batman");
+        assert_eq!(key.uids[1].name, "bruce wayne");
+        assert_eq!(key.uids[1].email, "bruce@wayne.com");
+    }
+
+    #[test]
+    fn unescape_colon_field_decodes_hex_escapes() {
+        // Verified against real gpg --with-colons output: a literal `:` is
+        // written as \x3a, a literal `\` as \x5c.
         assert_eq!(
-            key.secret_subkey.keygrip,
-            "4AC8E7E7FD8B405DF2761726D296F98C9B778875"
+            unescape_colon_field("Batman\\x3a Dark Knight"),
+            "Batman: Dark Knight"
+        );
+        assert_eq!(
+            unescape_colon_field("Batman \\x5c Robin"),
+            "Batman \\ Robin"
+        );
+        assert_eq!(unescape_colon_field("Bätman Ünïcode"), "Bätman Ünïcode");
+        assert_eq!(unescape_colon_field("no escapes here"), "no escapes here");
+    }
+
+    #[test]
+    fn unescape_colon_field_ignores_malformed_escape() {
+        assert_eq!(
+            unescape_colon_field("Batman\\xZZ Robin"),
+            "Batman\\xZZ Robin"
+        );
+        assert_eq!(unescape_colon_field("Batman\\x3"), "Batman\\x3");
+    }
+
+    #[test]
+    fn parse_uid_decodes_colon_hex_escape() {
+        let gpg_colon_format = "sec:u:4096:1:FDEFE8AB8796E127:1700000000:::u:::scESC:::+:::23::0:
+fpr:::::::::BEEA4CDB4B0A80CBABB99B45FDEFE8AB8796E127:
+grp:::::::::C4403DA4AF911084480BA46743E707CCDD082A24:
+uid:u::::1700000000::0E9C7598797E7F7A380A72A58B9B7FA28160AB06::Batman\\x3a Dark Knight <batman@dc.com>::::::::::0:";
+
+        let result = gpg_colon_format.parse::<GpgPrivateKey>();
+        assert!(
+            result.is_ok(),
+            "Should parse a uid containing a C-quoted colon"
+        );
+
+        let key = result.unwrap();
+        assert_eq!(key.primary_uid().name, "Batman: Dark Knight");
+        assert_eq!(key.primary_uid().email, "batman@dc.com");
+    }
+
+    #[test]
+    fn parse_uid_without_email() {
+        assert_eq!(
+            parse_uid("batman", 0, "uid:...:batman:").unwrap(),
+            GpgUid {
+                name: "batman".to_string(),
+                email: String::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_uid_with_unterminated_email_fails() {
+        let result = parse_uid("batman <batman@dc.com", 0, "uid:...:batman <batman@dc.com:");
+        assert!(matches!(result, Err(GpgError::MalformedKeyRecord(1, _))));
+    }
+
+    #[test]
+    fn parse_name_only_uid_key() {
+        let gpg_colon_format = "sec:u:4096:1:FDEFE8AB8796E127:1700000000:::u:::scESC:::+:::23::0:
+fpr:::::::::BEEA4CDB4B0A80CBABB99B45FDEFE8AB8796E127:
+grp:::::::::C4403DA4AF911084480BA46743E707CCDD082A24:
+uid:u::::1700000000::0E9C7598797E7F7A380A72A58B9B7FA28160AB06::batman::::::::::0:";
+
+        let result = gpg_colon_format.parse::<GpgPrivateKey>();
+        assert!(result.is_ok(), "A name-only uid should not fail parsing");
+
+        let key = result.unwrap();
+        assert_eq!(key.primary_uid().name, "batman");
+        assert_eq!(key.primary_uid().email, "");
+    }
+
+    #[test]
+    fn parse_uid_containing_record_tag_substrings() {
+        let gpg_colon_format = "sec:u:4096:1:FDEFE8AB8796E127:1700000000:::u:::scESC:::+:::23::0:
+fpr:::::::::BEEA4CDB4B0A80CBABB99B45FDEFE8AB8796E127:
+grp:::::::::C4403DA4AF911084480BA46743E707CCDD082A24:
+uid:u::::1700000000::0E9C7598797E7F7A380A72A58B9B7FA28160AB06::grossberg fpr sec ssb <grossberg@dc.com>::::::::::0:
+ssb:u:4096:1:BE6663F6A323FBE8:1700000000::::::e:::+:::23:
+fpr:::::::::F36BE03211AF1D3CE26D8B3ABE6663F6A323FBE8:
+grp:::::::::4AC8E7E7FD8B405DF2761726D296F98C9B778875:";
+
+        let result = gpg_colon_format.parse::<GpgPrivateKey>();
+        assert!(
+            result.is_ok(),
+            "A uid containing ssb/sec/fpr substrings should not derail parsing"
+        );
+
+        let key = result.unwrap();
+        assert_eq!(key.primary_uid().name, "grossberg fpr sec ssb");
+        assert_eq!(key.primary_uid().email, "grossberg@dc.com");
+        assert_eq!(key.subkeys.len(), 1);
+        assert_eq!(key.subkeys[0].key_id, "BE6663F6A323FBE8");
+    }
+
+    #[test]
+    fn parse_missing_sec_record_fails() {
+        let result = "uid:u::::1700000000::hash::batman <batman@dc.com>::::::::::0:"
+            .parse::<GpgPrivateKey>();
+
+        assert!(matches!(result, Err(GpgError::InvalidGpgKeyData(_))));
+    }
+
+    #[test]
+    fn parse_missing_uid_record_fails() {
+        let result = "sec:u:4096:1:FDEFE8AB8796E127:1700000000:::u:::scESC:::+:::23::0:
+fpr:::::::::BEEA4CDB4B0A80CBABB99B45FDEFE8AB8796E127:
+grp:::::::::C4403DA4AF911084480BA46743E707CCDD082A24:"
+            .parse::<GpgPrivateKey>();
+
+        assert!(matches!(result, Err(GpgError::InvalidGpgKeyData(_))));
+    }
+
+    #[test]
+    fn parse_truncated_record_reports_line_number() {
+        let result = "sec:u:4096:1:FDEFE8AB8796E127:1700000000\nuid:u::::1700000000::hash::batman <batman@dc.com>::::::::::0:"
+            .parse::<GpgPrivateKey>();
+
+        match result {
+            Err(GpgError::MalformedKeyRecord(line_no, _)) => assert_eq!(line_no, 1),
+            other => panic!("expected MalformedKeyRecord on line 1, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_sec_missing_fpr_and_grp_fails() {
+        let result = "sec:u:4096:1:FDEFE8AB8796E127:1700000000:::u:::scESC:::+:::23::0:
+uid:u::::1700000000::0E9C7598797E7F7A380A72A58B9B7FA28160AB06::batman <batman@dc.com>::::::::::0:"
+            .parse::<GpgPrivateKey>();
+
+        assert!(
+            matches!(result, Err(GpgError::InvalidGpgKeyData(_))),
+            "A sec record with no matching fpr/grp should not yield an empty fingerprint/keygrip: {result:?}"
+        );
+    }
+
+    #[test]
+    fn parse_ssb_missing_fpr_and_grp_fails() {
+        let result = "sec:u:4096:1:FDEFE8AB8796E127:1700000000:::u:::scESC:::+:::23::0:
+fpr:::::::::BEEA4CDB4B0A80CBABB99B45FDEFE8AB8796E127:
+grp:::::::::C4403DA4AF911084480BA46743E707CCDD082A24:
+uid:u::::1700000000::0E9C7598797E7F7A380A72A58B9B7FA28160AB06::batman <batman@dc.com>::::::::::0:
+ssb:u:4096:1:BE6663F6A323FBE8:1700000000::::::e:::+:::23:"
+            .parse::<GpgPrivateKey>();
+
+        assert!(
+            matches!(result, Err(GpgError::InvalidGpgKeyData(_))),
+            "An ssb record with no matching fpr/grp should not yield an empty fingerprint/keygrip: {result:?}"
+        );
+    }
+
+    #[test]
+    fn parse_multiple_sec_records_fails() {
+        let result = "sec:u:4096:1:FDEFE8AB8796E127:1700000000:::u:::scESC:::+:::23::0:
+fpr:::::::::BEEA4CDB4B0A80CBABB99B45FDEFE8AB8796E127:
+grp:::::::::C4403DA4AF911084480BA46743E707CCDD082A24:
+uid:u::::1700000000::0E9C7598797E7F7A380A72A58B9B7FA28160AB06::batman <batman@dc.com>::::::::::0:
+sec:u:4096:1:AAAAAAAAAAAAAAAA:1700000000:::u:::scESC:::+:::23::0:
+fpr:::::::::1111111111111111111111111111111111111111:
+grp:::::::::2222222222222222222222222222222222222222:
+uid:u::::1700000000::1E9C7598797E7F7A380A72A58B9B7FA28160AB07::robin <robin@dc.com>::::::::::0:"
+            .parse::<GpgPrivateKey>();
+
+        assert!(
+            matches!(result, Err(GpgError::InvalidGpgKeyData(_))),
+            "A second sec record must not silently merge into a hybrid of two keys: {result:?}"
         );
     }
 }

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,5 +1,6 @@
 use crate::{git, gpg};
 use anyhow::{bail, Result};
+use chrono::{TimeZone, Utc};
 use git2::Repository;
 
 /// A builder for importing GPG keys with optional configuration.
@@ -125,7 +126,9 @@ impl GpgImport {
 
         if !self.dry_run {
             gpg::preset_passphrase(&private_key.secret_key.keygrip, passphrase_cleaned)?;
-            gpg::preset_passphrase(&private_key.secret_subkey.keygrip, passphrase_cleaned)?;
+            for subkey in &private_key.subkeys {
+                gpg::preset_passphrase(&subkey.keygrip, passphrase_cleaned)?;
+            }
         }
 
         println!("> Setting Passphrase:");
@@ -133,10 +136,9 @@ impl GpgImport {
             "keygrip: {} [{}]",
             private_key.secret_key.keygrip, private_key.secret_key.key_id
         );
-        println!(
-            "keygrip: {} [{}]",
-            private_key.secret_subkey.keygrip, private_key.secret_subkey.key_id
-        );
+        for subkey in &private_key.subkeys {
+            println!("keygrip: {} [{}]", subkey.keygrip, subkey.key_id);
+        }
 
         Ok(())
     }
@@ -170,15 +172,22 @@ impl GpgImport {
         }
 
         let signing_key = self.resolve_signing_key(private_key)?;
+        validate_signing_key_expiry(private_key, &signing_key)?;
+        let primary_uid = private_key.primary_uid();
+        let user_email = self
+            .git_committer_email
+            .clone()
+            .unwrap_or_else(|| primary_uid.email.clone());
+        if user_email.trim().is_empty() {
+            bail!("primary GPG UID has no email; provide a Git committer email override");
+        }
+
         let git_cfg = git::SigningConfig {
             user_name: self
                 .git_committer_name
                 .clone()
-                .unwrap_or_else(|| private_key.user_name.clone()),
-            user_email: self
-                .git_committer_email
-                .clone()
-                .unwrap_or_else(|| private_key.user_email.clone()),
+                .unwrap_or_else(|| primary_uid.name.clone()),
+            user_email,
             key_id: signing_key,
             commit_sign: true,
             tag_sign: true,
@@ -194,9 +203,12 @@ impl GpgImport {
     fn resolve_signing_key(&self, private_key: &gpg::GpgPrivateKey) -> Result<String> {
         match &self.fingerprint {
             Some(fp) => {
-                if fp != &private_key.secret_key.fingerprint
-                    && fp != &private_key.secret_subkey.fingerprint
-                {
+                let matches_subkey = private_key
+                    .subkeys
+                    .iter()
+                    .any(|subkey| fp == &subkey.fingerprint);
+
+                if fp != &private_key.secret_key.fingerprint && !matches_subkey {
                     bail!(gpg::GpgError::FingerprintNotFound(fp.clone()));
                 }
                 Ok(fp.clone())
@@ -219,5 +231,283 @@ impl GpgImport {
         }
 
         Ok(())
+    }
+}
+
+/// Validates that the key actually selected for signing (as resolved by
+/// `resolve_signing_key`) isn't expired. `signing_key` is either a subkey's
+/// fingerprint (explicit `--fingerprint` selecting a subkey), the primary
+/// key's fingerprint, or the primary key's key id (default, no
+/// `--fingerprint`) -- only the first case names a subkey, so this only has
+/// something to check when `signing_key` matches one. The primary key's own
+/// expiry is already checked unconditionally by `gpg::extract_key_info`.
+fn validate_signing_key_expiry(private_key: &gpg::GpgPrivateKey, signing_key: &str) -> Result<()> {
+    let Some(subkey) = private_key
+        .subkeys
+        .iter()
+        .find(|subkey| subkey.fingerprint == signing_key)
+    else {
+        return Ok(());
+    };
+
+    if let Some(expiration_date) = subkey.expiration_date {
+        if expiration_date <= Utc::now().timestamp() {
+            bail!(
+                "the selected signing subkey has expired on {}",
+                Utc.timestamp_opt(expiration_date, 0).unwrap().to_rfc2822()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpg::{GpgCapabilities, GpgKeyDetails, GpgPrivateKey, GpgUid};
+    use serial_test::serial;
+    use std::{env, path::Path};
+    use tempfile::TempDir;
+
+    /// Temporarily changes the process's current directory, restoring it
+    /// when dropped. `git::is_repo` resolves the repo via
+    /// `Repository::open(".")`, so tests exercising git configuration need
+    /// to point the process at a throwaway repo instead of this project's
+    /// own checkout.
+    struct CwdGuard {
+        original: std::path::PathBuf,
+    }
+
+    impl CwdGuard {
+        fn change_to(path: &Path) -> std::io::Result<Self> {
+            let original = env::current_dir()?;
+            env::set_current_dir(path)?;
+            Ok(Self { original })
+        }
+    }
+
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            let _ = env::set_current_dir(&self.original);
+        }
+    }
+
+    fn key_with_uid_email(email: &str) -> GpgPrivateKey {
+        GpgPrivateKey {
+            uids: vec![GpgUid {
+                name: "batman".to_string(),
+                email: email.to_string(),
+            }],
+            secret_key: GpgKeyDetails {
+                creation_date: 0,
+                expiration_date: None,
+                fingerprint: "PRIMARYFPR".to_string(),
+                key_id: "PRIMARYKEYID".to_string(),
+                keygrip: "PRIMARYGRIP".to_string(),
+                capabilities: GpgCapabilities {
+                    sign: true,
+                    certify: true,
+                    ..Default::default()
+                },
+            },
+            subkeys: vec![],
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn configure_git_signing_bails_when_primary_uid_has_no_email() {
+        let repo_dir = TempDir::new().unwrap();
+        Repository::init(repo_dir.path()).expect("Failed to init throwaway git repo");
+        let _cwd_guard =
+            CwdGuard::change_to(repo_dir.path()).expect("Failed to change into throwaway repo");
+
+        let key = key_with_uid_email("");
+        let import = GpgImport::new("irrelevant".to_string());
+
+        let result = import.configure_git_signing(&key);
+        assert!(
+            result.is_err(),
+            "Should bail when the primary uid has no email and no override is given"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn configure_git_signing_accepts_committer_email_override_for_name_only_uid() {
+        let repo_dir = TempDir::new().unwrap();
+        Repository::init(repo_dir.path()).expect("Failed to init throwaway git repo");
+        let _cwd_guard =
+            CwdGuard::change_to(repo_dir.path()).expect("Failed to change into throwaway repo");
+
+        let key = key_with_uid_email("");
+        let import = GpgImport::new("irrelevant".to_string())
+            .with_git_committer_email(Some("batman@dc.com".to_string()));
+
+        let result = import.configure_git_signing(&key);
+        assert!(
+            result.is_ok(),
+            "A committer email override should satisfy the check: {:?}",
+            result.err()
+        );
+
+        let repo = Repository::open(repo_dir.path()).expect("Failed to reopen throwaway repo");
+        let config = repo.config().expect("Failed to read throwaway repo config");
+        assert_eq!(config.get_string("user.email").unwrap(), "batman@dc.com");
+    }
+
+    fn key_with_expiring_subkeys(subkeys: &[(&str, Option<i64>)]) -> GpgPrivateKey {
+        GpgPrivateKey {
+            uids: vec![GpgUid {
+                name: "batman".to_string(),
+                email: "batman@dc.com".to_string(),
+            }],
+            secret_key: GpgKeyDetails {
+                creation_date: 0,
+                expiration_date: None,
+                fingerprint: "PRIMARYFPR".to_string(),
+                key_id: "PRIMARYKEYID".to_string(),
+                keygrip: "PRIMARYGRIP".to_string(),
+                capabilities: GpgCapabilities {
+                    sign: true,
+                    certify: true,
+                    ..Default::default()
+                },
+            },
+            subkeys: subkeys
+                .iter()
+                .enumerate()
+                .map(|(i, (fp, expiration_date))| GpgKeyDetails {
+                    creation_date: 0,
+                    expiration_date: *expiration_date,
+                    fingerprint: fp.to_string(),
+                    key_id: format!("SUBKEYID{i}"),
+                    keygrip: format!("SUBKEYGRIP{i}"),
+                    capabilities: GpgCapabilities {
+                        sign: true,
+                        ..Default::default()
+                    },
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn configure_git_signing_rejects_expired_selected_subkey() {
+        let repo_dir = TempDir::new().unwrap();
+        Repository::init(repo_dir.path()).expect("Failed to init throwaway git repo");
+        let _cwd_guard =
+            CwdGuard::change_to(repo_dir.path()).expect("Failed to change into throwaway repo");
+
+        let expired = Utc::now().timestamp() - 86_400;
+        let key = key_with_expiring_subkeys(&[
+            ("FIRSTSUBKEYFPR", None),
+            ("SECONDSUBKEYFPR", Some(expired)),
+        ]);
+        let import = GpgImport::new("irrelevant".to_string())
+            .with_fingerprint(Some("SECONDSUBKEYFPR".to_string()));
+
+        let result = import.configure_git_signing(&key);
+        assert!(
+            result.is_err(),
+            "Should reject an expired subkey that was explicitly selected"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn configure_git_signing_ignores_expired_unselected_subkey() {
+        let repo_dir = TempDir::new().unwrap();
+        Repository::init(repo_dir.path()).expect("Failed to init throwaway git repo");
+        let _cwd_guard =
+            CwdGuard::change_to(repo_dir.path()).expect("Failed to change into throwaway repo");
+
+        let expired = Utc::now().timestamp() - 86_400;
+        // subkeys[0] is expired but not selected; a different, valid subkey is.
+        let key = key_with_expiring_subkeys(&[
+            ("FIRSTSUBKEYFPR", Some(expired)),
+            ("SECONDSUBKEYFPR", None),
+        ]);
+        let import = GpgImport::new("irrelevant".to_string())
+            .with_fingerprint(Some("SECONDSUBKEYFPR".to_string()));
+
+        let result = import.configure_git_signing(&key);
+        assert!(
+            result.is_ok(),
+            "An expired, unselected subkey must not block a different, valid selected subkey: {:?}",
+            result.err()
+        );
+    }
+
+    fn key_with_subkeys(subkey_fingerprints: &[&str]) -> GpgPrivateKey {
+        GpgPrivateKey {
+            uids: vec![GpgUid {
+                name: "batman".to_string(),
+                email: "batman@dc.com".to_string(),
+            }],
+            secret_key: GpgKeyDetails {
+                creation_date: 0,
+                expiration_date: None,
+                fingerprint: "PRIMARYFPR".to_string(),
+                key_id: "PRIMARYKEYID".to_string(),
+                keygrip: "PRIMARYGRIP".to_string(),
+                capabilities: GpgCapabilities {
+                    sign: true,
+                    certify: true,
+                    ..Default::default()
+                },
+            },
+            subkeys: subkey_fingerprints
+                .iter()
+                .enumerate()
+                .map(|(i, fp)| GpgKeyDetails {
+                    creation_date: 0,
+                    expiration_date: None,
+                    fingerprint: fp.to_string(),
+                    key_id: format!("SUBKEYID{i}"),
+                    keygrip: format!("SUBKEYGRIP{i}"),
+                    capabilities: GpgCapabilities {
+                        sign: true,
+                        ..Default::default()
+                    },
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn resolve_signing_key_accepts_non_first_subkey_fingerprint() {
+        let key = key_with_subkeys(&["FIRSTSUBKEYFPR", "SECONDSUBKEYFPR", "THIRDSUBKEYFPR"]);
+        let import = GpgImport::new("irrelevant".to_string())
+            .with_fingerprint(Some("THIRDSUBKEYFPR".to_string()));
+
+        let result = import.resolve_signing_key(&key);
+        assert!(
+            result.is_ok(),
+            "A --fingerprint matching a non-first subkey should resolve, not error: {:?}",
+            result.err()
+        );
+        assert_eq!(result.unwrap(), "THIRDSUBKEYFPR");
+    }
+
+    #[test]
+    fn resolve_signing_key_rejects_unknown_fingerprint() {
+        let key = key_with_subkeys(&["FIRSTSUBKEYFPR"]);
+        let import =
+            GpgImport::new("irrelevant".to_string()).with_fingerprint(Some("NOPE".to_string()));
+
+        let result = import.resolve_signing_key(&key);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_signing_key_defaults_to_primary_key_id() {
+        let key = key_with_subkeys(&["FIRSTSUBKEYFPR"]);
+        let import = GpgImport::new("irrelevant".to_string());
+
+        let result = import.resolve_signing_key(&key);
+        assert_eq!(result.unwrap(), "PRIMARYKEYID");
     }
 }

--- a/src/snapshots/gpg_import__gpg__tests__display_gpg_private_key_with_name_only_uid.snap
+++ b/src/snapshots/gpg_import__gpg__tests__display_gpg_private_key_with_name_only_uid.snap
@@ -1,0 +1,9 @@
+---
+source: src/gpg.rs
+expression: key.to_string()
+---
+user:           batman
+fingerprint:    BEEA4CDB4B0A80CBABB99B45FDEFE8AB8796E127
+keygrip:        C4403DA4AF911084480BA46743E707CCDD082A24
+key_id:         FDEFE8AB8796E127
+created_on:     Tue, 14 Nov 2023 22:13:20 +0000

--- a/tests/fixture/mod.rs
+++ b/tests/fixture/mod.rs
@@ -1,0 +1,316 @@
+//! Shared test fixtures, used across integration test binaries. Each
+//! binary only exercises a subset of these, so allow dead code rather
+//! than have every binary warn about the helpers it doesn't call.
+#![allow(dead_code)]
+
+use anyhow::{bail, Ok, Result};
+use gpg_import::gpg;
+use std::{env, fs, process::Command};
+use tempfile::TempDir;
+
+static GNUPGHOME: &str = "GNUPGHOME";
+
+/// Formats a bare `YYYY-MM-DD` date into a frozen `faketime -f` spec.
+///
+/// Plain `faketime <date>` (without `-f`) only sets a starting point; the
+/// wall clock then keeps advancing in real elapsed time from each process's
+/// own start. Two separate faketime invocations sharing the same bare date
+/// (e.g. generating a primary key, then later adding a subkey to it) can
+/// therefore drift against each other by a fraction of a second, which gpg
+/// intermittently rejects with "key ... was created 1 second in the future
+/// (time warp or clock problem)" -- reproduced directly under concurrent
+/// load. `-f "YYYY-MM-DD hh:mm:ss"` freezes the clock at an exact instant,
+/// so every invocation using the same date reports the identical timestamp.
+fn freeze_at(date: &str) -> String {
+    format!("{date} 00:00:00")
+}
+
+/// Restores the process's original GNUPGHOME on drop. Installed as a local
+/// variable before any fallible configuration step during fixture
+/// construction, so an early `?` return still restores the environment
+/// (via normal drop-on-return) before the temp directory it pointed at is
+/// deleted; folded into `GpgTestFixture` on success to keep protecting it
+/// for the fixture's lifetime.
+struct GnupghomeGuard {
+    original: Option<String>,
+}
+
+impl GnupghomeGuard {
+    fn install(new_value: &str) -> Self {
+        let original = env::var(GNUPGHOME).ok();
+        env::set_var(GNUPGHOME, new_value);
+        Self { original }
+    }
+}
+
+impl Drop for GnupghomeGuard {
+    fn drop(&mut self) {
+        match &self.original {
+            Some(original) => env::set_var(GNUPGHOME, original),
+            None => env::remove_var(GNUPGHOME),
+        }
+    }
+}
+
+/// A test fixture that creates an isolated GPG home directory
+/// and cleans it up automatically when dropped
+pub struct GpgTestFixture {
+    temp_dir: TempDir,
+    gnupghome_guard: GnupghomeGuard,
+}
+
+impl GpgTestFixture {
+    pub fn new() -> Result<Self> {
+        if !Self::is_gpg_available() {
+            bail!("GPG is required for tests. Please install GPG to run tests.")
+        }
+
+        let temp_dir = TempDir::new()?;
+        let gnupg_home = temp_dir.path().to_string_lossy().to_string();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(temp_dir.path())?.permissions();
+            perms.set_mode(0o700);
+            fs::set_permissions(temp_dir.path(), perms)?;
+        }
+
+        let gnupghome_guard = GnupghomeGuard::install(&gnupg_home);
+
+        gpg::configure_defaults(&gnupg_home)?;
+        gpg::configure_agent_defaults(&gnupg_home)?;
+
+        Ok(Self {
+            temp_dir,
+            gnupghome_guard,
+        })
+    }
+
+    fn is_gpg_available() -> bool {
+        Command::new("gpg")
+            .arg("--version")
+            .output()
+            .is_ok_and(|output| output.status.success())
+    }
+
+    #[cfg(unix)]
+    pub fn batch_generate_key_on(&self, batch_config: &str, yyyy_mm_dd: &str) -> Result<String> {
+        self.generate_key(batch_config, Some(yyyy_mm_dd))
+    }
+
+    pub fn generate_key(&self, batch_config: &str, created_date: Option<&str>) -> Result<String> {
+        let batch_file_path = self.temp_dir.path().join("batch_config.txt");
+        fs::write(&batch_file_path, batch_config)?;
+
+        let output = if let Some(date) = created_date {
+            Command::new("faketime")
+                .arg("-f")
+                .arg(freeze_at(date))
+                .arg("gpg")
+                .arg("--batch")
+                .arg("--generate-key")
+                .arg(&batch_file_path)
+                .output()?
+        } else {
+            Command::new("gpg")
+                .arg("--batch")
+                .arg("--generate-key")
+                .arg(&batch_file_path)
+                .output()?
+        };
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            println!("Failed to generate GPG key: {}", stderr);
+            bail!("Failed to generate GPG key: {}", stderr);
+        }
+
+        // Get the fingerprint of the generated key
+        self.get_latest_key_fingerprint()
+    }
+
+    /// Adds an additional subkey with the given usage (e.g. "sign", "encrypt",
+    /// "auth") to an existing, unprotected primary key
+    pub fn add_subkey(&self, fingerprint: &str, usage: &str) -> Result<()> {
+        let output = Command::new("gpg")
+            .args([
+                "--batch",
+                "--pinentry-mode",
+                "loopback",
+                "--passphrase",
+                "",
+                "--yes",
+                "--quick-add-key",
+                fingerprint,
+                "rsa2048",
+                usage,
+            ])
+            .output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("Failed to add {} subkey: {}", usage, stderr);
+        }
+
+        Ok(())
+    }
+
+    /// Adds an additional subkey protected by the given passphrase to an
+    /// existing, passphrase-protected primary key
+    pub fn add_protected_subkey(
+        &self,
+        fingerprint: &str,
+        usage: &str,
+        passphrase: &str,
+    ) -> Result<()> {
+        let output = Command::new("gpg")
+            .args([
+                "--batch",
+                "--pinentry-mode",
+                "loopback",
+                "--passphrase",
+                passphrase,
+                "--yes",
+                "--quick-add-key",
+                fingerprint,
+                "rsa2048",
+                usage,
+            ])
+            .output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("Failed to add {} subkey: {}", usage, stderr);
+        }
+
+        Ok(())
+    }
+
+    /// Exports the ASCII-armored secret key material for a fingerprint
+    /// already present in the keyring
+    pub fn export_secret_key(&self, fingerprint: &str) -> Result<String> {
+        let output = Command::new("gpg")
+            .args(["--armor", "--export-secret-key", fingerprint])
+            .output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("Failed to export secret key: {}", stderr);
+        }
+
+        Ok(String::from_utf8(output.stdout)?)
+    }
+
+    /// Exports the ASCII-armored secret key material for a passphrase-protected
+    /// fingerprint already present in the keyring
+    pub fn export_protected_secret_key(
+        &self,
+        fingerprint: &str,
+        passphrase: &str,
+    ) -> Result<String> {
+        let output = Command::new("gpg")
+            .args([
+                "--batch",
+                "--pinentry-mode",
+                "loopback",
+                "--passphrase",
+                passphrase,
+                "--armor",
+                "--export-secret-key",
+                fingerprint,
+            ])
+            .output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("Failed to export secret key: {}", stderr);
+        }
+
+        Ok(String::from_utf8(output.stdout)?)
+    }
+
+    /// Kills this fixture's gpg-agent (it respawns fresh, with an empty
+    /// cache, on the next gpg invocation). Setup steps that authenticate
+    /// with a real passphrase (e.g. `add_protected_subkey`,
+    /// `export_protected_secret_key`) may leave agent-implementation-defined
+    /// cache state behind; call this before asserting that a later signing
+    /// step genuinely required its own explicit passphrase preset, so the
+    /// assertion doesn't depend on incidental caching from setup.
+    pub fn kill_agent(&self) -> Result<()> {
+        let output = Command::new("gpgconf")
+            .args(["--kill", "gpg-agent"])
+            .output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("Failed to kill gpg-agent: {}", stderr);
+        }
+
+        Ok(())
+    }
+
+    /// Get the fingerprint of the most recently generated key
+    fn get_latest_key_fingerprint(&self) -> Result<String> {
+        let output = Command::new("gpg")
+            .arg("--list-secret-keys")
+            .arg("--with-colons")
+            .arg("--fingerprint")
+            .output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("Failed to list GPG keys: {}", stderr);
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        for line in stdout.lines() {
+            if line.starts_with("fpr:") {
+                let parts: Vec<&str> = line.split(':').collect();
+                if parts.len() > 9 && !parts[9].is_empty() {
+                    return Ok(parts[9].to_string());
+                }
+            }
+        }
+
+        bail!("Could not find fingerprint in GPG output")
+    }
+
+    pub fn create_and_sign_file(&self, fingerprint: &str) -> Result<()> {
+        let content = "Lorem ipsum dolor sit amet consectetur adipiscing elit. \
+                       Quisque faucibus ex sapien vitae pellentesque sem placerat. \
+                       In id cursus mi pretium tellus duis convallis. \
+                       Tempus leo eu aenean sed diam urna tempor. \
+                       Pulvinar vivamus fringilla lacus nec metus bibendum egestas. \
+                       Iaculis massa nisl malesuada lacinia integer nunc posuere. \
+                       Ut hendrerit semper vel class aptent taciti sociosqu. \
+                       Ad litora torquent per conubia nostra inceptos himenaeos.";
+
+        let file_path = self.temp_dir.path().join("test_file.txt");
+        fs::write(&file_path, content)?;
+
+        let signature_path = file_path.with_extension("sig");
+        let output = Command::new("gpg")
+            .arg("--batch")
+            .arg("--yes")
+            .arg("--local-user")
+            .arg(fingerprint)
+            .arg("--detach-sign")
+            .arg("--output")
+            .arg(&signature_path)
+            .arg(&file_path)
+            .output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("Failed to sign file: {}", stderr);
+        }
+
+        if !signature_path.exists() {
+            bail!("Signature file was not created");
+        }
+
+        Ok(())
+    }
+}

--- a/tests/gpg.rs
+++ b/tests/gpg.rs
@@ -1,11 +1,10 @@
-use anyhow::{bail, Ok, Result};
 use chrono::{Duration, Utc};
 use gpg_import::gpg;
 use serial_test::serial;
-use std::{env, fs, process::Command};
-use tempfile::TempDir;
+use std::env;
 
-static GNUPGHOME: &str = "GNUPGHOME";
+mod fixture;
+use fixture::GpgTestFixture;
 
 #[derive(Default)]
 struct GpgBatchConfig {
@@ -46,156 +45,6 @@ Name-Email: batman@dc.com"
         batch_content.push_str("\n%no-protection");
         batch_content.push_str("\n%commit\n");
         batch_content
-    }
-}
-
-/// A test fixture that creates an isolated GPG home directory
-/// and cleans it up automatically when dropped
-struct GpgTestFixture {
-    temp_dir: TempDir,
-    original_gnupghome: Option<String>,
-}
-
-impl GpgTestFixture {
-    fn new() -> Result<Self> {
-        if !Self::is_gpg_available() {
-            bail!("GPG is required for tests. Please install GPG to run tests.")
-        }
-
-        let temp_dir = TempDir::new()?;
-        let gnupg_home = temp_dir.path().to_string_lossy().to_string();
-
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(temp_dir.path())?.permissions();
-        perms.set_mode(0o700);
-        fs::set_permissions(temp_dir.path(), perms)?;
-
-        // Save original GNUPGHOME, allowing it to be restored later
-        let original_gnupghome = env::var(GNUPGHOME).ok();
-        env::set_var(GNUPGHOME, &gnupg_home);
-
-        gpg::configure_defaults(&gnupg_home)?;
-        gpg::configure_agent_defaults(&gnupg_home)?;
-
-        Ok(Self {
-            temp_dir,
-            original_gnupghome,
-        })
-    }
-
-    fn is_gpg_available() -> bool {
-        Command::new("gpg")
-            .arg("--version")
-            .output()
-            .is_ok_and(|output| output.status.success())
-    }
-
-    #[cfg(unix)]
-    fn batch_generate_key_on(&self, batch_config: &str, yyyy_mm_dd: &str) -> Result<String> {
-        self.generate_key(batch_config, Some(yyyy_mm_dd))
-    }
-
-    fn generate_key(&self, batch_config: &str, created_date: Option<&str>) -> Result<String> {
-        let batch_file_path = self.temp_dir.path().join("batch_config.txt");
-        fs::write(&batch_file_path, batch_config)?;
-
-        let output = if let Some(date) = created_date {
-            Command::new("faketime")
-                .arg(date)
-                .arg("gpg")
-                .arg("--batch")
-                .arg("--generate-key")
-                .arg(&batch_file_path)
-                .output()?
-        } else {
-            Command::new("gpg")
-                .arg("--batch")
-                .arg("--generate-key")
-                .arg(&batch_file_path)
-                .output()?
-        };
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            println!("Failed to generate GPG key: {}", stderr);
-            bail!("Failed to generate GPG key: {}", stderr);
-        }
-
-        // Get the fingerprint of the generated key
-        self.get_latest_key_fingerprint()
-    }
-
-    /// Get the fingerprint of the most recently generated key
-    fn get_latest_key_fingerprint(&self) -> Result<String> {
-        let output = Command::new("gpg")
-            .arg("--list-secret-keys")
-            .arg("--with-colons")
-            .arg("--fingerprint")
-            .output()?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            bail!("Failed to list GPG keys: {}", stderr);
-        }
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-
-        for line in stdout.lines() {
-            if line.starts_with("fpr:") {
-                let parts: Vec<&str> = line.split(':').collect();
-                if parts.len() > 9 && !parts[9].is_empty() {
-                    return Ok(parts[9].to_string());
-                }
-            }
-        }
-
-        bail!("Could not find fingerprint in GPG output")
-    }
-
-    fn create_and_sign_file(&self, fingerprint: &str) -> Result<()> {
-        let content = "Lorem ipsum dolor sit amet consectetur adipiscing elit. \
-                       Quisque faucibus ex sapien vitae pellentesque sem placerat. \
-                       In id cursus mi pretium tellus duis convallis. \
-                       Tempus leo eu aenean sed diam urna tempor. \
-                       Pulvinar vivamus fringilla lacus nec metus bibendum egestas. \
-                       Iaculis massa nisl malesuada lacinia integer nunc posuere. \
-                       Ut hendrerit semper vel class aptent taciti sociosqu. \
-                       Ad litora torquent per conubia nostra inceptos himenaeos.";
-
-        let file_path = self.temp_dir.path().join("test_file.txt");
-        fs::write(&file_path, content)?;
-
-        let signature_path = file_path.with_extension("sig");
-        let output = Command::new("gpg")
-            .arg("--batch")
-            .arg("--yes")
-            .arg("--local-user")
-            .arg(fingerprint)
-            .arg("--detach-sign")
-            .arg("--output")
-            .arg(&signature_path)
-            .arg(&file_path)
-            .output()?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            bail!("Failed to sign file: {}", stderr);
-        }
-
-        if !signature_path.exists() {
-            bail!("Signature file was not created");
-        }
-
-        Ok(())
-    }
-}
-
-impl Drop for GpgTestFixture {
-    fn drop(&mut self) {
-        match &self.original_gnupghome {
-            Some(original) => env::set_var(GNUPGHOME, original),
-            _ => env::remove_var(GNUPGHOME),
-        }
     }
 }
 
@@ -336,7 +185,13 @@ fn extract_key_info_expired_secret_key() {
 
 #[test]
 #[serial]
-fn extract_key_info_expired_secret_subkey() {
+fn extract_key_info_does_not_reject_expired_subkey() {
+    // extract_key_info doesn't know which key (if any) will be selected for
+    // signing, so it intentionally leaves subkey-expiry enforcement to
+    // GpgImport::configure_git_signing, which validates expiry for the
+    // specific key actually resolved for signing. See
+    // configure_git_signing_rejects_expired_selected_subkey and
+    // configure_git_signing_ignores_expired_unselected_subkey in import.rs.
     let fixture = GpgTestFixture::new();
     assert!(fixture.is_ok(), "Failed to create GPG test fixture");
 
@@ -356,16 +211,260 @@ fn extract_key_info_expired_secret_subkey() {
 
     let result = gpg::extract_key_info(&result.unwrap());
     assert!(
-        result.is_err(),
-        "Failed to extract key info for expired secret subkey"
+        result.is_ok(),
+        "extract_key_info should not fail on an expired subkey: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+#[serial]
+fn extract_key_info_sign_only_no_subkey() {
+    let fixture = GpgTestFixture::new();
+    assert!(fixture.is_ok(), "Failed to create GPG test fixture");
+    let fixture = fixture.unwrap();
+
+    let batch_config = "Key-Type: RSA
+Key-Length: 2048
+Key-Usage: sign
+Name-Real: robin
+Name-Email: robin@dc.com
+%no-protection
+%commit
+";
+
+    let fingerprint = fixture.generate_key(batch_config, None);
+    assert!(fingerprint.is_ok(), "Failed to generate sign-only GPG key");
+    let fingerprint = fingerprint.unwrap();
+
+    let key_info = gpg::extract_key_info(&fingerprint);
+    assert!(
+        key_info.is_ok(),
+        "Should extract info for a sign-only key with no subkey"
     );
 
-    let error = result.unwrap_err();
-    let error_message = format!("{}", error);
+    let key_info = key_info.unwrap();
     assert!(
-        error_message.contains("GPG secret subkey has expired on"),
-        "Expected error message does not match"
+        key_info.subkeys.is_empty(),
+        "Sign-only key should have no subkeys"
     );
+    assert_eq!(key_info.primary_uid().name, "robin");
+
+    let sign_result = fixture.create_and_sign_file(&key_info.secret_key.fingerprint);
+    assert!(
+        sign_result.is_ok(),
+        "Sign-only key should still be able to sign"
+    );
+}
+
+#[test]
+#[serial]
+fn extract_key_info_multiple_subkeys() {
+    let fixture = GpgTestFixture::new();
+    assert!(fixture.is_ok(), "Failed to create GPG test fixture");
+    let fixture = fixture.unwrap();
+
+    let batch_config = "Key-Type: RSA
+Key-Length: 2048
+Key-Usage: sign
+Name-Real: batman
+Name-Email: batman@dc.com
+%no-protection
+%commit
+";
+
+    let fingerprint = fixture.generate_key(batch_config, None);
+    assert!(fingerprint.is_ok(), "Failed to generate primary key");
+    let fingerprint = fingerprint.unwrap();
+
+    // The signing-capable subkey is deliberately added after an encryption
+    // subkey, mirroring key rotation where the original encrypt subkey
+    // precedes a later-added signing subkey.
+    assert!(
+        fixture.add_subkey(&fingerprint, "encrypt").is_ok(),
+        "Failed to add encrypt subkey"
+    );
+    assert!(
+        fixture.add_subkey(&fingerprint, "sign").is_ok(),
+        "Failed to add sign subkey"
+    );
+    assert!(
+        fixture.add_subkey(&fingerprint, "auth").is_ok(),
+        "Failed to add auth subkey"
+    );
+
+    let key_info = gpg::extract_key_info(&fingerprint);
+    assert!(
+        key_info.is_ok(),
+        "Should extract info for a key with 3 subkeys"
+    );
+
+    let key_info = key_info.unwrap();
+    assert_eq!(key_info.subkeys.len(), 3, "Should parse all 3 subkeys");
+    assert!(key_info.subkeys[0].capabilities.encrypt);
+    assert!(key_info.subkeys[1].capabilities.sign);
+    assert!(key_info.subkeys[2].capabilities.authenticate);
+
+    let signing_subkey = key_info.subkeys.iter().find(|k| k.capabilities.sign);
+    assert!(
+        signing_subkey.is_some_and(|k| !k.fingerprint.is_empty() && !k.keygrip.is_empty()),
+        "The non-first signing-capable subkey should have a fingerprint and keygrip"
+    );
+}
+
+#[test]
+#[serial]
+fn preset_passphrase_for_every_subkey_allows_non_first_subkey_to_sign() {
+    let fixture = GpgTestFixture::new();
+    assert!(fixture.is_ok(), "Failed to create GPG test fixture");
+    let fixture = fixture.unwrap();
+
+    let passphrase = "gotham";
+    let batch_config = format!(
+        "Key-Type: RSA
+Key-Length: 2048
+Key-Usage: sign
+Name-Real: batman
+Name-Email: batman@dc.com
+Passphrase: {passphrase}
+%commit
+"
+    );
+
+    let fingerprint = fixture.generate_key(&batch_config, None);
+    assert!(fingerprint.is_ok(), "Failed to generate primary key");
+    let fingerprint = fingerprint.unwrap();
+
+    // Signing-capable subkey deliberately not first, mirroring the scenario
+    // where configure_gpg_passphrase previously only preset subkeys.first().
+    assert!(
+        fixture
+            .add_protected_subkey(&fingerprint, "encrypt", passphrase)
+            .is_ok(),
+        "Failed to add encrypt subkey"
+    );
+    assert!(
+        fixture
+            .add_protected_subkey(&fingerprint, "sign", passphrase)
+            .is_ok(),
+        "Failed to add sign subkey"
+    );
+
+    let key_info = gpg::extract_key_info(&fingerprint);
+    assert!(key_info.is_ok(), "Failed to extract key info");
+    let key_info = key_info.unwrap();
+    assert_eq!(key_info.subkeys.len(), 2);
+
+    // add_protected_subkey authenticated with the real passphrase above; kill
+    // the agent so any residual cache from that setup can't make the signing
+    // assertion below pass regardless of whether the preset loop works.
+    assert!(fixture.kill_agent().is_ok(), "Failed to kill gpg-agent");
+
+    // Mirrors GpgImport::configure_gpg_passphrase: preset primary + every subkey.
+    assert!(gpg::preset_passphrase(&key_info.secret_key.keygrip, passphrase).is_ok());
+    for subkey in &key_info.subkeys {
+        assert!(
+            gpg::preset_passphrase(&subkey.keygrip, passphrase).is_ok(),
+            "Failed to preset passphrase for subkey {}",
+            subkey.key_id
+        );
+    }
+
+    // The non-first (sign) subkey must be able to sign without prompting,
+    // since its passphrase was preset above.
+    let signing_subkey = &key_info.subkeys[1];
+    assert!(signing_subkey.capabilities.sign);
+    let sign_result = fixture.create_and_sign_file(&signing_subkey.fingerprint);
+    assert!(
+        sign_result.is_ok(),
+        "Non-first subkey should sign without a passphrase prompt: {:?}",
+        sign_result.err()
+    );
+}
+
+#[test]
+#[serial]
+fn preview_key_sign_only_no_subkey() {
+    let fixture = GpgTestFixture::new();
+    assert!(fixture.is_ok(), "Failed to create GPG test fixture");
+    let fixture = fixture.unwrap();
+
+    let batch_config = "Key-Type: RSA
+Key-Length: 2048
+Key-Usage: sign
+Name-Real: robin
+Name-Email: robin@dc.com
+%no-protection
+%commit
+";
+
+    let fingerprint = fixture.generate_key(batch_config, None);
+    assert!(fingerprint.is_ok(), "Failed to generate sign-only GPG key");
+    let fingerprint = fingerprint.unwrap();
+
+    let armored = fixture.export_secret_key(&fingerprint);
+    assert!(armored.is_ok(), "Failed to export sign-only GPG key");
+
+    // preview_key uses a different gpg invocation (`--import-options show-only`,
+    // without --fixed-list-mode) to extract_key_info's (`--list-secret-keys`),
+    // so the zero-subkey case is verified independently here.
+    let result = gpg::preview_key(&armored.unwrap());
+    assert!(result.is_ok(), "Should preview a sign-only key");
+
+    let key = result.unwrap();
+    assert!(
+        key.subkeys.is_empty(),
+        "Sign-only key should have no subkeys"
+    );
+    assert_eq!(key.primary_uid().name, "robin");
+}
+
+#[test]
+#[serial]
+fn preview_key_multiple_subkeys() {
+    let fixture = GpgTestFixture::new();
+    assert!(fixture.is_ok(), "Failed to create GPG test fixture");
+    let fixture = fixture.unwrap();
+
+    let batch_config = "Key-Type: RSA
+Key-Length: 2048
+Key-Usage: sign
+Name-Real: batman
+Name-Email: batman@dc.com
+%no-protection
+%commit
+";
+
+    let fingerprint = fixture.generate_key(batch_config, None);
+    assert!(fingerprint.is_ok(), "Failed to generate primary key");
+    let fingerprint = fingerprint.unwrap();
+
+    // Same encrypt-then-sign-then-auth ordering as extract_key_info_multiple_subkeys,
+    // exercised here through preview_key's separate gpg invocation.
+    assert!(
+        fixture.add_subkey(&fingerprint, "encrypt").is_ok(),
+        "Failed to add encrypt subkey"
+    );
+    assert!(
+        fixture.add_subkey(&fingerprint, "sign").is_ok(),
+        "Failed to add sign subkey"
+    );
+    assert!(
+        fixture.add_subkey(&fingerprint, "auth").is_ok(),
+        "Failed to add auth subkey"
+    );
+
+    let armored = fixture.export_secret_key(&fingerprint);
+    assert!(armored.is_ok(), "Failed to export multi-subkey GPG key");
+
+    let result = gpg::preview_key(&armored.unwrap());
+    assert!(result.is_ok(), "Should preview a key with 3 subkeys");
+
+    let key = result.unwrap();
+    assert_eq!(key.subkeys.len(), 3, "Should parse all 3 subkeys");
+    assert!(key.subkeys[0].capabilities.encrypt);
+    assert!(key.subkeys[1].capabilities.sign);
+    assert!(key.subkeys[2].capabilities.authenticate);
 }
 
 #[test]
@@ -396,13 +495,14 @@ fn preview_key_base64() {
     assert!(result.is_ok(), "Should preview GPG key");
 
     let key = result.unwrap();
-    assert_eq!(key.user_name, "batman");
-    assert_eq!(key.user_email, "batman@dc.com");
+    assert_eq!(key.primary_uid().name, "batman");
+    assert_eq!(key.primary_uid().email, "batman@dc.com");
     assert!(!key.secret_key.fingerprint.is_empty());
     assert!(!key.secret_key.key_id.is_empty());
     assert!(!key.secret_key.keygrip.is_empty());
-    assert!(!key.secret_subkey.key_id.is_empty());
-    assert!(!key.secret_subkey.keygrip.is_empty());
+    assert_eq!(key.subkeys.len(), 1);
+    assert!(!key.subkeys[0].key_id.is_empty());
+    assert!(!key.subkeys[0].keygrip.is_empty());
 }
 
 #[test]
@@ -495,13 +595,14 @@ fn preview_key_ascii_armored() {
     assert!(result.is_ok(), "Should preview ASCII armored GPG key");
 
     let key = result.unwrap();
-    assert_eq!(key.user_name, "batman");
-    assert_eq!(key.user_email, "batman@dc.com");
+    assert_eq!(key.primary_uid().name, "batman");
+    assert_eq!(key.primary_uid().email, "batman@dc.com");
     assert!(!key.secret_key.fingerprint.is_empty());
     assert!(!key.secret_key.key_id.is_empty());
     assert!(!key.secret_key.keygrip.is_empty());
-    assert!(!key.secret_subkey.key_id.is_empty());
-    assert!(!key.secret_subkey.keygrip.is_empty());
+    assert_eq!(key.subkeys.len(), 1);
+    assert!(!key.subkeys[0].key_id.is_empty());
+    assert!(!key.subkeys[0].keygrip.is_empty());
 }
 
 #[test]

--- a/tests/import.rs
+++ b/tests/import.rs
@@ -1,0 +1,126 @@
+use git2::Repository;
+use gpg_import::{gpg, import::GpgImport};
+use serial_test::serial;
+use std::{env, path::Path};
+use tempfile::TempDir;
+
+mod fixture;
+use fixture::GpgTestFixture;
+
+/// Temporarily changes the process's current directory, restoring it when
+/// dropped. `git::is_repo` resolves the repo via `Repository::open(".")`,
+/// so tests that exercise git configuration need to point the process at a
+/// throwaway repo instead of this project's own checkout.
+struct CwdGuard {
+    original: std::path::PathBuf,
+}
+
+impl CwdGuard {
+    fn change_to(path: &Path) -> std::io::Result<Self> {
+        let original = env::current_dir()?;
+        env::set_current_dir(path)?;
+        Ok(Self { original })
+    }
+}
+
+impl Drop for CwdGuard {
+    fn drop(&mut self) {
+        let _ = env::set_current_dir(&self.original);
+    }
+}
+
+#[test]
+#[serial]
+fn import_resolves_and_signs_with_non_first_subkey_via_fingerprint() {
+    let fixture = GpgTestFixture::new();
+    assert!(fixture.is_ok(), "Failed to create GPG test fixture");
+    let fixture = fixture.unwrap();
+
+    let passphrase = "gotham";
+    let batch_config = format!(
+        "Key-Type: RSA
+Key-Length: 2048
+Key-Usage: sign
+Name-Real: batman
+Name-Email: batman@dc.com
+Passphrase: {passphrase}
+%commit
+"
+    );
+
+    let fingerprint = fixture.generate_key(&batch_config, None);
+    assert!(fingerprint.is_ok(), "Failed to generate primary key");
+    let fingerprint = fingerprint.unwrap();
+
+    // Signing-capable subkey deliberately added after an encrypt subkey, so
+    // it is not subkeys[0] -- exactly the case resolve_signing_key's
+    // matches_subkey fix addresses.
+    assert!(
+        fixture
+            .add_protected_subkey(&fingerprint, "encrypt", passphrase)
+            .is_ok(),
+        "Failed to add encrypt subkey"
+    );
+    assert!(
+        fixture
+            .add_protected_subkey(&fingerprint, "sign", passphrase)
+            .is_ok(),
+        "Failed to add sign subkey"
+    );
+
+    let armored = fixture.export_protected_secret_key(&fingerprint, passphrase);
+    assert!(armored.is_ok(), "Failed to export multi-subkey GPG key");
+    let armored = armored.unwrap();
+
+    // export_protected_secret_key authenticated with the real passphrase
+    // above; kill the agent so any residual cache from that setup can't make
+    // the signing assertion below pass regardless of whether
+    // GpgImport::import()'s own passphrase-preset step actually works.
+    assert!(fixture.kill_agent().is_ok(), "Failed to kill gpg-agent");
+
+    let key_info = gpg::extract_key_info(&fingerprint);
+    assert!(key_info.is_ok(), "Failed to extract key info");
+    let key_info = key_info.unwrap();
+    assert_eq!(key_info.subkeys.len(), 2, "Expected 2 subkeys");
+    assert!(
+        key_info.subkeys[1].capabilities.sign,
+        "The non-first subkey should be the signing-capable one"
+    );
+    let signing_subkey_fingerprint = key_info.subkeys[1].fingerprint.clone();
+
+    // Run GpgImport::import() against a throwaway repo (never the real
+    // project checkout), selecting the non-first subkey by fingerprint --
+    // the CLI --fingerprint path affected by the resolve_signing_key bug.
+    let repo_dir = TempDir::new().unwrap();
+    Repository::init(repo_dir.path()).expect("Failed to init throwaway git repo");
+    let _cwd_guard =
+        CwdGuard::change_to(repo_dir.path()).expect("Failed to change into throwaway repo");
+
+    let result = GpgImport::new(armored)
+        .with_passphrase(Some(passphrase.to_string()))
+        .with_fingerprint(Some(signing_subkey_fingerprint.clone()))
+        .import();
+
+    assert!(
+        result.is_ok(),
+        "GpgImport::import() should resolve a non-first subkey fingerprint, not error: {:?}",
+        result.err()
+    );
+
+    let repo = Repository::open(repo_dir.path()).expect("Failed to reopen throwaway repo");
+    let config = repo.config().expect("Failed to read throwaway repo config");
+    let signing_key = config
+        .get_string("user.signingKey")
+        .expect("user.signingKey should be set");
+    assert_eq!(
+        signing_key, signing_subkey_fingerprint,
+        "git should be configured to sign with the requested non-first subkey"
+    );
+
+    let sign_result = fixture.create_and_sign_file(&signing_subkey_fingerprint);
+    assert!(
+        sign_result.is_ok(),
+        "The selected non-first subkey should sign without a passphrase prompt: {:?}",
+        sign_result.err()
+    );
+}


### PR DESCRIPTION
closes #217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved support for GPG keys with multiple user IDs and multiple secret subkeys, including enhanced capability parsing and updated key preview details (primary UID plus per-subkey info).
* **Bug Fixes**
  * More precise malformed-key diagnostics with line-number reporting.
  * Signing key resolution now accepts the correct matching subkey fingerprint, and expiration handling is more accurate.
  * Passphrase preset now applies to the secret key and all secret subkeys during configuration.
  * Git signing identity now derives committer details from the primary UID and fails when the email is missing (unless overridden).
* **Tests**
  * Expanded coverage for multi-UID/multi-subkey, capability, and non-first signing subkey scenarios; updated snapshots and fixtures.
* **Chores**
  * Improved test fixture isolation and updated ignore patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->