### PR TITLE
fix(deps): update dependencies and migrate to Rust edition 2024

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ jobs:
     name: rustfmt / stable
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Nix
-        uses: cachix/install-nix-action@a49548c11d9846ad46ecc0115273879b045f001c # v31
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -52,10 +52,10 @@ jobs:
     name: clippy / stable
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Nix
-        uses: cachix/install-nix-action@a49548c11d9846ad46ecc0115273879b045f001c # v31
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -81,7 +81,7 @@ jobs:
     name: build-fast / linux_x86_64_musl
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
@@ -110,10 +110,10 @@ jobs:
         os: [ubuntu-24.04, macos-15]
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Nix
-        uses: cachix/install-nix-action@a49548c11d9846ad46ecc0115273879b045f001c # v31
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -158,7 +158,7 @@ jobs:
             use-zigbuild: false
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/code-security.yml
+++ b/.github/workflows/code-security.yml
@@ -24,7 +24,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -29,10 +29,10 @@ jobs:
     if: github.actor != 'renovate[bot]'
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Nix
-        uses: cachix/install-nix-action@a49548c11d9846ad46ecc0115273879b045f001c # v31
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
 
       - name: Setup Cachix
         uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
@@ -52,10 +52,10 @@ jobs:
         os: [ubuntu-24.04, macos-15]
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Nix
-        uses: cachix/install-nix-action@a49548c11d9846ad46ecc0115273879b045f001c # v31
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
 
       - name: Setup Cachix
         uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17

--- a/.github/workflows/nsv.yaml
+++ b/.github/workflows/nsv.yaml
@@ -8,13 +8,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_NSV }}
 
       - name: Install Nix
-        uses: cachix/install-nix-action@a49548c11d9846ad46ecc0115273879b045f001c # v31
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
             use-zigbuild: false
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
@@ -109,12 +109,12 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       - name: Install Nix
-        uses: cachix/install-nix-action@a49548c11d9846ad46ecc0115273879b045f001c # v31
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -18,10 +18,10 @@ jobs:
     name: shellcheck
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Nix
-        uses: cachix/install-nix-action@a49548c11d9846ad46ecc0115273879b045f001c # v31
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -41,10 +41,10 @@ jobs:
     name: shfmt
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Nix
-        uses: cachix/install-nix-action@a49548c11d9846ad46ecc0115273879b045f001c # v31
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -21,10 +21,10 @@ jobs:
     name: check spelling
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Nix
-        uses: cachix/install-nix-action@a49548c11d9846ad46ecc0115273879b045f001c # v31
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "autocfg"
@@ -75,9 +75,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
 name = "bitflags"
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -152,14 +152,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -559,9 +559,9 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serial_test"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+checksum = "a6df5ed973ad8d834e09f824f9e9f449af6b9a3745f78dec7cc752770bd3bf11"
 dependencies = [
  "futures-executor",
  "futures-util",
@@ -573,13 +573,13 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+checksum = "a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -618,6 +618,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,22 +643,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -699,7 +710,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -721,7 +732,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -756,7 +767,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -767,7 +778,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,9 @@
 authors = ["Purple Clay <purpleclaygh@gmail.com>"]
 description = "Import and configure GPG signing for git"
 name = "gpg-import"
-edition = "2021"
+edition = "2024"
 license = "MIT"
+rust-version = "1.97.1"
 version = "0.9.1"
 
 [profile.release]
@@ -11,7 +12,7 @@ strip = "debuginfo"
 
 [dependencies]
 anyhow = "1.0.86"
-base64 = "0.22.0"
+base64 = "0.23.0"
 chrono = { version = "0.4.31", default-features = false, features = [
     "std",
     "clock",
@@ -25,7 +26,7 @@ thiserror = "2.0.0"
 
 [dev-dependencies]
 insta = "1.42"
-serial_test = "3.0"
+serial_test = "4.0"
 
 [build-dependencies]
 built = { version = "0.8.0", features = ["git2", "semver", "chrono"] }

--- a/flake.lock
+++ b/flake.lock
@@ -37,53 +37,31 @@
     "git-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1769939035,
-        "narHash": "sha256-Fok2AmefgVA0+eprw2NDwqKkPGEI5wvR+twiZagBvrg=",
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "a8ca480175326551d6c4121498316261cbb5b260",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770019141,
-        "narHash": "sha256-VKS4ZLNx4PNrABoB0L8KUpc1fE7CLpQXQs985tGfaCU=",
+        "lastModified": 1785571196,
+        "narHash": "sha256-KoTsyMQqnXQZq8deCEnu4QkyldkwH/bpMMhUcfMdGIw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cb369ef2efd432b3cdf8622b0ffc0a97a02f3137",
+        "rev": "148bab9c1c3c53136ecb44a6ea356a0ed5b39b06",
         "type": "github"
       },
       "original": {
@@ -108,11 +86,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770088046,
-        "narHash": "sha256-4hfYDnUTvL1qSSZEA4CEThxfz+KlwSFQ30Z9jgDguO0=",
+        "lastModified": 1785648791,
+        "narHash": "sha256-4wZa7NDOxbcm9pTNNcg88nvvPb9uVcWsJ+Ncil8eB1I=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "71f9daa4e05e49c434d08627e755495ae222bc34",
+        "rev": "32346a8154e65fa10bac36f7b476a5294cb8b150",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
 
         inherit (nixpkgs) lib;
 
-        rustToolchain = pkgs.rust-bin.stable."1.87.0".default.override {
+        rustToolchain = pkgs.rust-bin.stable."1.97.1".default.override {
           extensions = ["rust-src" "cargo" "rustc" "clippy" "rustfmt"];
         };
 
@@ -48,10 +48,11 @@
           alejandra
           cargo-insta
           cargo-nextest
+          gnupg
           libfaketime
           nil
-          nodePackages.prettier
           openssl
+          prettier
           shellcheck
           shfmt
           typos

--- a/src/gpg.rs
+++ b/src/gpg.rs
@@ -1,13 +1,13 @@
-use anyhow::{bail, Result};
-use base64::{engine::general_purpose, DecodeError, Engine as _};
+use anyhow::{Result, bail};
+use base64::{DecodeError, Engine as _, engine::general_purpose};
 use chrono::{TimeZone, Utc};
 use nom::{
+    AsChar, Finish, IResult, Parser,
     branch::alt,
     bytes::complete::{tag, take_until},
     character::complete::not_line_ending,
     error::Error,
     sequence::separated_pair,
-    AsChar, Finish, IResult, Parser,
 };
 use std::{
     fmt::{self, Display},
@@ -649,13 +649,13 @@ pub fn extract_key_info(key_id: &str) -> Result<GpgPrivateKey> {
     let key_details = output.parse::<GpgPrivateKey>()?;
 
     let current_timestamp = Utc::now().timestamp();
-    if let Some(expiration_date) = key_details.secret_key.expiration_date {
-        if expiration_date <= current_timestamp {
-            bail!(
-                "GPG secret key has expired on {}",
-                Utc.timestamp_opt(expiration_date, 0).unwrap().to_rfc2822()
-            );
-        }
+    if let Some(expiration_date) = key_details.secret_key.expiration_date
+        && expiration_date <= current_timestamp
+    {
+        bail!(
+            "GPG secret key has expired on {}",
+            Utc.timestamp_opt(expiration_date, 0).unwrap().to_rfc2822()
+        );
     }
 
     // Subkey expiry is intentionally not checked here: which subkey (if any)
@@ -683,7 +683,7 @@ pub fn preset_passphrase(keygrip: &str, passphrase: &str) -> Result<()> {
             format!(
                 "PRESET_PASSPHRASE {} -1 {}",
                 keygrip,
-                &hex::encode(passphrase).to_uppercase()
+                hex::encode(passphrase).to_uppercase()
             )
             .as_bytes(),
         )?;

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,5 +1,5 @@
 use crate::{git, gpg};
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use chrono::{TimeZone, Utc};
 use git2::Repository;
 
@@ -250,13 +250,13 @@ fn validate_signing_key_expiry(private_key: &gpg::GpgPrivateKey, signing_key: &s
         return Ok(());
     };
 
-    if let Some(expiration_date) = subkey.expiration_date {
-        if expiration_date <= Utc::now().timestamp() {
-            bail!(
-                "the selected signing subkey has expired on {}",
-                Utc.timestamp_opt(expiration_date, 0).unwrap().to_rfc2822()
-            );
-        }
+    if let Some(expiration_date) = subkey.expiration_date
+        && expiration_date <= Utc::now().timestamp()
+    {
+        bail!(
+            "the selected signing subkey has expired on {}",
+            Utc.timestamp_opt(expiration_date, 0).unwrap().to_rfc2822()
+        );
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{command, Parser, Subcommand, ValueEnum};
+use clap::{Parser, Subcommand, ValueEnum};
 use gpg_import::import::GpgImport;
 use std::io::Read;
 use std::println;
@@ -119,7 +119,11 @@ fn main() -> Result<()> {
         }
     }
 
-    let key_input = args.key.ok_or_else(|| anyhow::anyhow!("Key is required for GPG import. Use --key or set GPG_PRIVATE_KEY environment variable."))?;
+    let key_input = args.key.ok_or_else(|| {
+        anyhow::anyhow!(
+            "Key is required for GPG import. Use --key or set GPG_PRIVATE_KEY environment variable."
+        )
+    })?;
     let key = resolve_key_input(&key_input)?;
 
     GpgImport::new(key)

--- a/tests/fixture/mod.rs
+++ b/tests/fixture/mod.rs
@@ -3,7 +3,7 @@
 //! than have every binary warn about the helpers it doesn't call.
 #![allow(dead_code)]
 
-use anyhow::{bail, Ok, Result};
+use anyhow::{Ok, Result, bail};
 use gpg_import::gpg;
 use std::{env, fs, process::Command};
 use tempfile::TempDir;
@@ -38,7 +38,8 @@ struct GnupghomeGuard {
 impl GnupghomeGuard {
     fn install(new_value: &str) -> Self {
         let original = env::var(GNUPGHOME).ok();
-        env::set_var(GNUPGHOME, new_value);
+        // FIXME: Audit that the environment access only happens in single-threaded code.
+        unsafe { env::set_var(GNUPGHOME, new_value) };
         Self { original }
     }
 }
@@ -46,8 +47,10 @@ impl GnupghomeGuard {
 impl Drop for GnupghomeGuard {
     fn drop(&mut self) {
         match &self.original {
-            Some(original) => env::set_var(GNUPGHOME, original),
-            None => env::remove_var(GNUPGHOME),
+            // FIXME: Audit that the environment access only happens in single-threaded code.
+            Some(original) => unsafe { env::set_var(GNUPGHOME, original) },
+            // FIXME: Audit that the environment access only happens in single-threaded code.
+            None => unsafe { env::remove_var(GNUPGHOME) },
         }
     }
 }

--- a/tests/gpg.rs
+++ b/tests/gpg.rs
@@ -76,7 +76,8 @@ impl LocaleGuard {
             .iter()
             .map(|(name, value)| {
                 let original = env::var(name).ok();
-                env::set_var(name, value);
+                // FIXME: Audit that the environment access only happens in single-threaded code.
+                unsafe { env::set_var(name, value) };
                 (*name, original)
             })
             .collect();
@@ -89,8 +90,10 @@ impl Drop for LocaleGuard {
     fn drop(&mut self) {
         for (name, original) in &self.originals {
             match original {
-                Some(value) => env::set_var(name, value),
-                None => env::remove_var(name),
+                // FIXME: Audit that the environment access only happens in single-threaded code.
+                Some(value) => unsafe { env::set_var(name, value) },
+                // FIXME: Audit that the environment access only happens in single-threaded code.
+                None => unsafe { env::remove_var(name) },
             }
         }
     }
@@ -539,7 +542,7 @@ fn import_secret_key_valid_base64_invalid_gpg_data() {
     assert!(fixture.is_ok(), "Failed to create GPG test fixture");
     let _fixture = fixture.unwrap();
 
-    use base64::{engine::general_purpose, Engine as _};
+    use base64::{Engine as _, engine::general_purpose};
     let invalid_gpg_data = general_purpose::STANDARD.encode("not a gpg key");
 
     let result = gpg::import_secret_key(&invalid_gpg_data);


### PR DESCRIPTION
closes #228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the project to Rust 2024 with Rust 1.97.1 support.
  * Upgraded Base64 and test tooling.
  * Refreshed the Rust toolchain and formatting tools.
  * Updated pinned automation actions across CI, security, testing, build, and release workflows.

* **Refactor**
  * Modernized Rust syntax and environment handling while preserving existing behavior.

* **Style**
  * Applied import ordering and formatting updates throughout the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->